### PR TITLE
Rename everything to `webhook`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,11 +17,11 @@ lambda-runtime:linuxX64Test:
     - trunk
     - external_pull_requests
 
-slackbot:linuxX64Test:
+webhook:linuxX64Test:
   image: gradle:7.4.2-jdk11
   stage: test
   needs: ["lambda-runtime:linuxX64Test", "lambda-runtime:jvmTest"]
-  script: gradle :slackbot:linuxX64Test
+  script: gradle :webhook:linuxX64Test
   only:
     - trunk
     - external_pull_requests

--- a/aws/rie-entry-script.sh
+++ b/aws/rie-entry-script.sh
@@ -3,4 +3,4 @@ set -e
 set -u
 set -o pipefail
 
-exec /usr/local/bin/aws-lambda-rie /usr/local/bin/slackbot.kexe $@
+exec /usr/local/bin/aws-lambda-rie /usr/local/bin/webhook.kexe $@

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 
-rootProject.name = "hoa-slackbot"
+rootProject.name = "hoa-webhook"
 
 include(":multiplatform-aws-lambda-runtime")
-include(":slackbot")
+include(":webhook")

--- a/test.dockerfile
+++ b/test.dockerfile
@@ -2,11 +2,11 @@ FROM gradle:7.4.2-jdk11 AS build
 RUN mkdir -p /app
 COPY ./ /app
 WORKDIR /app
-RUN gradle --no-daemon :slackbot:linkReleaseExecutableLinuxX64
+RUN gradle --no-daemon :webhook:linkReleaseExecutableLinuxX64
 
 FROM debian:buster-slim
 WORKDIR /app
-COPY --from=build /app/slackbot/build/bin/linuxX64/releaseExecutable/slackbot.kexe /usr/local/bin
+COPY --from=build /app/webhook/build/bin/linuxX64/releaseExecutable/webhook.kexe /usr/local/bin
 COPY aws/rie-entry-script.sh /entry_script.sh
 ADD aws/aws-lambda-rie /usr/local/bin/aws-lambda-rie
 

--- a/webhook/build.gradle.kts
+++ b/webhook/build.gradle.kts
@@ -10,7 +10,7 @@ kotlin {
   linuxX64 {
     binaries {
       executable {
-        entryPoint = "org.climatechangemakers.hoa.slackbot.main"
+        entryPoint = "org.climatechangemakers.hoa.webhook.main"
       }
     }
   }

--- a/webhook/src/commonMain/kotlin/org/climatechangemakers/hoa/webhook/Main.kt
+++ b/webhook/src/commonMain/kotlin/org/climatechangemakers/hoa/webhook/Main.kt
@@ -1,4 +1,4 @@
-package org.climatechangemakers.hoa.slackbot
+package org.climatechangemakers.hoa.webhook
 
 import kotlinx.coroutines.runBlocking
 import org.climatechangemakers.lambda.model.InvocationRequest

--- a/webhook/src/commonTest/kotlin/org/climatechangemakers/hoa/webhook/SampleTest.kt
+++ b/webhook/src/commonTest/kotlin/org/climatechangemakers/hoa/webhook/SampleTest.kt
@@ -1,4 +1,4 @@
-package org.climatechangemakers.hoa.slackbot
+package org.climatechangemakers.hoa.webhook
 
 import kotlin.test.Test
 import kotlin.test.assertEquals


### PR DESCRIPTION
We're no longer going to be using this as a Slackbot, thankfully. 
Instead, we'll be setting up a webhook that's invoked from lu.ma 
every time someone signs up for, or attends, an Hour of Action. 