### PR TITLE
Push Docker container to AWS ECR

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,10 +1,7 @@
-services:
-  - docker:dind
-
 stages:
   - test
   - build
-  - deploy
+  - publish
 
 lambda-runtime:jvmTest:
   image: gradle:7.4.2-jdk11
@@ -37,8 +34,10 @@ docker:build:
   image: docker:stable
   stage: build
   needs: []
+  services:
+    - docker:dind
   variables:
-    TAGGED_IMAGE: "$IMAGE_TAG:$CI_COMMIT_SHORT_SHA"
+    TAGGED_IMAGE: "$IMAGE_REPOSITORY:$CI_COMMIT_SHORT_SHA"
   script:
     - docker build -t $TAGGED_IMAGE . -f production.dockerfile
     - docker save $TAGGED_IMAGE > build.tar
@@ -49,15 +48,20 @@ docker:build:
     - trunk
     - external_pull_requests
 
-docker:deploy:
+ecr:publish:
   image: docker:stable
-  stage: deploy
+  stage: publish
+  services:
+    - docker:dind
   needs: ["webhook:linuxX64Test", "docker:build"]
   variables:
-    TAGGED_IMAGE: "$IMAGE_TAG:$CI_COMMIT_SHORT_SHA"
+    TAGGED_IMAGE: "$IMAGE_REPOSITORY:$CI_COMMIT_SHORT_SHA"
+  before_script:
+    - apk add --no-cache curl jq python3 py3-pip
+    - pip install awscli
   script:
     - docker load -i build.tar
-    - docker login -u $GITLAB_USER_LOGIN -p $GITLAB_API_KEY registry.gitlab.com
-    - docker push $IMAGE_TAG
+    - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $AWS_ECR_ACCOUNT
+    - docker push $IMAGE_REPOSITORY
   only:
     - trunk


### PR DESCRIPTION
Docker containers that run on AWS lambda are required to be stored in
AWS Elastic Container Registry. Prior to this commit, our images were
stored in Gitlab container registry.
