### PR TITLE
Add logging to Lambda Runtime Interface Client

### DIFF
--- a/multiplatform-aws-lambda-runtime/src/commonMain/kotlin/org/climatechangemakers/lambda/runtime/run.kt
+++ b/multiplatform-aws-lambda-runtime/src/commonMain/kotlin/org/climatechangemakers/lambda/runtime/run.kt
@@ -56,9 +56,11 @@ private suspend fun handleEvent(
 ): InvocationResponse? = try {
   handler(event)
 } catch (e: LambdaHandlerException) {
+  println("Reporting LambdaHandlerException $e.")
   service.reportInvocationError(requestId = event.requestId, error = e)
   null
 } catch (e: Throwable) {
+  println("Reporting Throwable $e.")
   service.reportInvocationError(requestId = event.requestId, error = LambdaHandlerException(cause = e))
   null
 }


### PR DESCRIPTION
For some reason, a SerializationException is being thrown by the Lambda
handler, but the invocation error isn't being reported anywhere.

I think the implementation of the RIC is slightly wrong, and this
logging will help debug the issue.
